### PR TITLE
Fixes #8: mel loss should have a gradient function

### DIFF
--- a/utils/stft.py
+++ b/utils/stft.py
@@ -158,11 +158,13 @@ class TacotronSTFT(torch.nn.Module):
         output = dynamic_range_decompression(magnitudes)
         return output
 
-    def mel_spectrogram(self, y):
+    def mel_spectrogram(self, y, requires_grad=False):
         """Computes mel-spectrograms from a batch of waves
         PARAMS
         ------
-        y: Variable(torch.FloatTensor) with shape (B, T) in range [-1, 1]
+        y             : Variable(torch.FloatTensor) with shape (B, T) in range [-1, 1]
+        requires_grad : bool
+
         RETURNS
         -------
         mel_output: torch.FloatTensor of shape (B, n_mel_channels, T)
@@ -171,7 +173,10 @@ class TacotronSTFT(torch.nn.Module):
         assert(torch.max(y.data) <= 1)
 
         magnitudes, phases = self.stft_fn.transform(y)
-        magnitudes = magnitudes.data
+
+        if not requires_grad:
+            magnitudes = magnitudes.data
+
         mel_output = torch.matmul(self.mel_basis, magnitudes)
         mel_output = self.spectral_normalize(mel_output)
         return mel_output

--- a/utils/train.py
+++ b/utils/train.py
@@ -103,8 +103,6 @@ def train(args, pt_dir, chkpt_path, trainloader, valloader, writer, logger, hp, 
 
                 loss_g = 0.0
 
-
-
                 sc_loss, mag_loss = stft_loss(fake_audio[:, :, :audioG.size(2)].squeeze(1), audioG.squeeze(1))
                 loss_g += sc_loss + mag_loss # STFT Loss
 
@@ -131,7 +129,7 @@ def train(args, pt_dir, chkpt_path, trainloader, valloader, writer, logger, hp, 
                     adv_loss = adv_loss + adv_mpd_loss # Adv Loss
 
                     # Mel Loss
-                    mel_fake = stft.mel_spectrogram(fake_audio.squeeze(1))
+                    mel_fake = stft.mel_spectrogram(fake_audio.squeeze(1), requires_grad=True)
                     loss_mel += l1loss(melG[:, :, :mel_fake.size(2)], mel_fake.cuda()) # Mel L1 loss
                     loss_g += hp.model.lambda_mel * loss_mel
 
@@ -143,9 +141,6 @@ def train(args, pt_dir, chkpt_path, trainloader, valloader, writer, logger, hp, 
                         for feats_fake, feats_real in zip(mpd_fake_feats, mpd_real_feats):
                             for feat_f, feat_r in zip(feats_fake, feats_real):
                                 adv_loss += hp.model.feat_match * torch.mean(torch.abs(feat_f - feat_r))
-
-
-
 
                     loss_g += hp.model.lambda_adv * adv_loss
 
@@ -185,7 +180,6 @@ def train(args, pt_dir, chkpt_path, trainloader, valloader, writer, logger, hp, 
                         loss_d.backward()
                         optim_d.step()
                         loss_d_sum += loss_mpd
-
 
                     loss_d_avg = loss_d_sum / hp.train.rep_discriminator
                     loss_d_avg = loss_d_avg.item()


### PR DESCRIPTION
Added an optional parameter, `requires_grad` (default value is False) to the stft melspectrogram function. When this function is used during training, the gradients should be preserved. 