### PR TITLE
fix: typo in a variable name

### DIFF
--- a/model/generator.py
+++ b/model/generator.py
@@ -123,10 +123,9 @@ class Generator(nn.Module):
         self.apply(_apply_weight_norm)
 
     def inference(self, mel):
-        hop_length = 256
         # pad input mel with zeros to cut artifact
         # see https://github.com/seungwonpark/melgan/issues/8
-        zero = torch.full((1, self.mel_channel, 10), -11.5129).to(mel.device)
+        zero = torch.full((1, self.input_channel, 10), -11.5129).to(mel.device)
         mel = torch.cat((mel, zero), dim=2)
 
         audio = self.forward(mel)


### PR DESCRIPTION
Hi! I've noticed that there is a variable with a wrong (probably just old) name that somehow was left behind. As for hop length - it doesn't really matter in this context. I examined a trick with the removal of clicking noise. I tested that it all works right.